### PR TITLE
fix(document): wrap document save in try-catch for cleanup on failure

### DIFF
--- a/Prn212.AIStudyHub.Services/Documents/DocumentService.Commands.cs
+++ b/Prn212.AIStudyHub.Services/Documents/DocumentService.Commands.cs
@@ -50,10 +50,19 @@ public partial class DocumentService
       UploadedAt = DateTime.UtcNow
     };
 
-    using var context = new AistudyHubDbContext();
-    context.Documents.Add(document);
-    await context.SaveChangesAsync();
-    return document;
+    try
+    {
+      using var context = new AistudyHubDbContext();
+      context.Documents.Add(document);
+      await context.SaveChangesAsync();
+      return document;
+    }
+    catch
+    {
+      if (File.Exists(destinationPath))
+        File.Delete(destinationPath);
+      throw;
+    }
   }
 
   public async Task UpdateMetadataAsync(int documentId, string title, int subjectId)


### PR DESCRIPTION
Fixed: #26 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved upload handling so failed saves now clean up the uploaded file, preventing leftover files when the database operation does not complete.
  * Preserved the original error behavior while adding safer rollback-style cleanup during uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->