### PR TITLE
refactor(document): refactor ViewDocumentWindow to remove document selection

### DIFF
--- a/Prn212.AIStudyHub.WPF/Views/Documents/ViewDocumentWindow.xaml
+++ b/Prn212.AIStudyHub.WPF/Views/Documents/ViewDocumentWindow.xaml
@@ -12,9 +12,7 @@
     <Grid Margin="20">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
-            <RowDefinition Height="Auto"/>
             <RowDefinition Height="*"/>
-            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
@@ -23,16 +21,8 @@
                    Style="{StaticResource SubHeaderTextBlockStyle}"
                    Margin="0,0,0,20"/>
 
-        <!-- Document Selection -->
-        <StackPanel Grid.Row="1" Margin="0,0,0,15">
-            <TextBlock Text="Chọn tài liệu để xem (*)" Style="{StaticResource FormLabelStyle}"/>
-            <ComboBox x:Name="cbDocuments" Style="{StaticResource ModernComboBoxStyle}"
-                      DisplayMemberPath="Title" SelectedValuePath="Id"
-                      SelectionChanged="CbDocuments_SelectionChanged"/>
-        </StackPanel>
-
         <!-- Document Details -->
-        <ScrollViewer Grid.Row="2" VerticalScrollBarVisibility="Auto">
+        <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
             <StackPanel x:Name="spDocumentDetails" Margin="0,0,0,15">
                 <!-- Title -->
                 <TextBlock Text="Tiêu đề:" Style="{StaticResource FormLabelStyle}"/>
@@ -77,7 +67,7 @@
         </ScrollViewer>
 
         <!-- Action Buttons -->
-        <UniformGrid Grid.Row="3" Columns="3" Rows="1" Height="38" Margin="0,0,0,15">
+        <UniformGrid Grid.Row="2" Columns="3" Rows="1" Height="38" Margin="0,0,0,15">
             <Button x:Name="btnDownload" Content="⬇ Tải Xuống" Margin="0,0,5,0" 
                     Click="BtnDownload_Click" Style="{StaticResource SuccessButtonStyle}"
                     IsEnabled="False"/>
@@ -89,8 +79,5 @@
                     IsEnabled="False"/>
         </UniformGrid>
 
-        <!-- Close Button -->
-        <Button Grid.Row="4" x:Name="btnCancel" Content="Đóng" Height="38" 
-                Click="BtnCancel_Click" Style="{StaticResource DangerButtonStyle}"/>
     </Grid>
 </Window>

--- a/Prn212.AIStudyHub.WPF/Views/Documents/ViewDocumentWindow.xaml.cs
+++ b/Prn212.AIStudyHub.WPF/Views/Documents/ViewDocumentWindow.xaml.cs
@@ -2,7 +2,6 @@ using Microsoft.Win32;
 using Prn212.AIStudyHub.DataAccess;
 using Prn212.AIStudyHub.Services.Documents;
 using System.Windows;
-using System.Windows.Controls;
 
 namespace Prn212.AIStudyHub.WPF.Views.Documents
 {
@@ -27,48 +26,21 @@ namespace Prn212.AIStudyHub.WPF.Views.Documents
     {
       try
       {
-        LoadDocuments();
         if (_initialDocumentId.HasValue)
         {
-          cbDocuments.SelectedValue = _initialDocumentId.Value;
+          LoadDocumentDetail(_initialDocumentId.Value);
+        }
+        else
+        {
+          MessageBox.Show("Vui lòng chọn tài liệu trước khi xem chi tiết.",
+                          "Cảnh báo", MessageBoxButton.OK, MessageBoxImage.Warning);
+          this.Close();
         }
       }
       catch (Exception ex)
       {
         MessageBox.Show($"Lỗi khi tải dữ liệu:\n{ex.Message}",
                         "Lỗi tải dữ liệu", MessageBoxButton.OK, MessageBoxImage.Error);
-      }
-    }
-
-    /// <summary>
-    /// Tải danh sách tài liệu từ service (không filter, trang 1, 100 item)
-    /// </summary>
-    private void LoadDocuments()
-    {
-      try
-      {
-        var (documents, totalCount) = _documentService.SearchDocuments(page: 1, pageSize: 100);
-        cbDocuments.ItemsSource = documents;
-      }
-      catch (Exception ex)
-      {
-        MessageBox.Show($"Lỗi tải danh sách tài liệu:\n{ex.Message}",
-                        "Lỗi", MessageBoxButton.OK, MessageBoxImage.Error);
-      }
-    }
-
-    /// <summary>
-    /// Event: Khi người dùng chọn tài liệu từ combobox
-    /// </summary>
-    private void CbDocuments_SelectionChanged(object sender, SelectionChangedEventArgs e)
-    {
-      if (cbDocuments.SelectedItem is Document selectedDoc)
-      {
-        LoadDocumentDetail(selectedDoc.Id);
-      }
-      else
-      {
-        ClearDocumentDetail();
       }
     }
 
@@ -176,7 +148,6 @@ namespace Prn212.AIStudyHub.WPF.Views.Documents
           btnDownload.IsEnabled = false;
           btnEdit.IsEnabled = false;
           btnDelete.IsEnabled = false;
-          btnCancel.IsEnabled = false;
 
           // Gọi service để download
           await _documentService.DownloadAsync(_currentDocument.Id, destPath, progress);
@@ -204,7 +175,6 @@ namespace Prn212.AIStudyHub.WPF.Views.Documents
           btnDownload.IsEnabled = true;
           btnEdit.IsEnabled = true;
           btnDelete.IsEnabled = true;
-          btnCancel.IsEnabled = true;
         }
       }
     }
@@ -230,9 +200,6 @@ namespace Prn212.AIStudyHub.WPF.Views.Documents
 
         // Sau khi sửa xong, tải lại chi tiết tài liệu
         LoadDocumentDetail(_currentDocument.Id);
-
-        // Reload danh sách để thấy thay đổi
-        LoadDocuments();
       }
       catch (Exception ex)
       {
@@ -276,9 +243,8 @@ namespace Prn212.AIStudyHub.WPF.Views.Documents
           MessageBox.Show("Xóa tài liệu thành công!",
                           "Thông báo", MessageBoxButton.OK, MessageBoxImage.Information);
 
-          // Tải lại danh sách
-          LoadDocuments();
-          ClearDocumentDetail();
+          // Đóng cửa sổ vì tài liệu đã bị xóa thành công
+          this.Close();
         }
         catch (Exception ex)
         {
@@ -313,14 +279,6 @@ namespace Prn212.AIStudyHub.WPF.Views.Documents
       }
 
       return $"{len:F2} {sizes[order]}";
-    }
-
-    /// <summary>
-    /// Nút Cancel: Đóng cửa sổ
-    /// </summary>
-    private void BtnCancel_Click(object sender, RoutedEventArgs e)
-    {
-      this.Close();
     }
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The document viewer now opens directly to a selected document’s details instead of showing a document list first.
  * If no document is available to display, the window now shows a warning and closes cleanly.
  * After editing or deleting a document, the screen now stays focused on the current document or closes appropriately.
  * The interface has been simplified by removing the extra document selector and close button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->