### PR TITLE
Validation for email and Name. Fix Refresh Token

### DIFF
--- a/Prn212.AIStudyHub.WPF/Prn212.AIStudyHub.WPF.csproj
+++ b/Prn212.AIStudyHub.WPF/Prn212.AIStudyHub.WPF.csproj
@@ -20,4 +20,11 @@
     <PackageReference Include="System.Net.Http.Json" Version="10.0.10" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\src\PRN212.AIStudyHub.Application\PRN212.AIStudyHub.Application.csproj" />
+    <ProjectReference Include="..\src\PRN212.AIStudyHub.Domain\PRN212.AIStudyHub.Domain.csproj" />
+    <ProjectReference Include="..\src\PRN212.AIStudyHub.Infrastructure\PRN212.AIStudyHub.Infrastructure.csproj" />
+    <ProjectReference Include="..\src\PRN212.AIStudyHub.WebAPI\PRN212.AIStudyHub.WebAPI.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/Prn212.AIStudyHub.WPF/Views/Auth/ManageUsersWindow.xaml.cs
+++ b/Prn212.AIStudyHub.WPF/Views/Auth/ManageUsersWindow.xaml.cs
@@ -1,5 +1,4 @@
 using Prn212.AIStudyHub.DataAccess;
-using Prn212.AIStudyHub.Services.Auth;
 using System.Windows;
 using System.Windows.Controls;
 

--- a/src/PRN212.AIStudyHub.Application/Services/AuthService.cs
+++ b/src/PRN212.AIStudyHub.Application/Services/AuthService.cs
@@ -4,119 +4,144 @@ using PRN212.AIStudyHub.Application.Interfaces;
 using PRN212.AIStudyHub.Application.Interfaces.Security;
 using PRN212.AIStudyHub.Domain.Entities;
 using System.Security.Cryptography;
+using PRN212.AIStudyHub.Application.Utils;
 
 namespace PRN212.AIStudyHub.Application.Services;
 
 public class AuthService(IAppDbContext context, IPasswordHasher passwordHasher, IJwtTokenGenerator jwtTokenGenerator) : IAuthService
 {
-  public async Task<AuthResponse> LoginAsync(LoginRequest request, CancellationToken cancellationToken = default)
-  {
-    // Validate the input parameters
-    if (string.IsNullOrWhiteSpace(request.Email) || string.IsNullOrWhiteSpace(request.Password))
+    public async Task<AuthResponse> LoginAsync(LoginRequest request, CancellationToken cancellationToken = default)
     {
-      throw new ArgumentException("Email and password are required");
+        // Validate the input parameters
+        if (string.IsNullOrWhiteSpace(request.Email) || string.IsNullOrWhiteSpace(request.Password))
+        {
+            throw new ArgumentException("Email and password are required");
+        }
+
+        // Validate format email
+        if (!ValidationUtils.IsValidEmail(request.Email))
+        {
+            throw new ArgumentException("Invalid email format");
+        }
+
+        // Query the user from the database based on the provided email
+        var user = await context.AppUsers.AsNoTracking().FirstOrDefaultAsync(u => u.Email == request.Email, cancellationToken);
+
+        // Check if the user exists and if the provided password matches the stored password hash
+        if (user is null || !passwordHasher.VerifyPassword(request.Password, user.PasswordHash))
+        {
+            throw new InvalidOperationException("Invalid credentials");
+        }
+
+        // Check if the user account is active
+        if (!user.IsActive)
+        {
+            throw new InvalidOperationException("User account is inactive");
+        }
+
+        return await GenerateAuthResponseAsync(user, cancellationToken);
     }
 
-    // Query the user from the database based on the provided email
-    var user = await context.AppUsers.AsNoTracking().FirstOrDefaultAsync(u => u.Email == request.Email, cancellationToken);
-
-    // Check if the user exists and if the provided password matches the stored password hash
-    if (user is null || !passwordHasher.VerifyPassword(request.Password, user.PasswordHash))
+    public async Task<AuthResponse> RegisterAsync(RegisterRequest request, CancellationToken cancellationToken = default)
     {
-      throw new InvalidOperationException("Invalid credentials");
+        // Validate the input parameters
+        if (string.IsNullOrWhiteSpace(request.Email) || string.IsNullOrWhiteSpace(request.Password) || string.IsNullOrWhiteSpace(request.ConfirmPassword) || string.IsNullOrWhiteSpace(request.FirstName) || string.IsNullOrWhiteSpace(request.LastName))
+        {
+            throw new ArgumentException("All fields are required");
+        }
+
+        // Validate format for email
+        if (!ValidationUtils.IsValidEmail(request.Email))
+        {
+            throw new ArgumentException("Invalid email format");
+        }
+
+        // Validate format for first name (allow Vietnamese)
+        if (!ValidationUtils.IsValidName(request.FirstName))
+        {
+            throw new ArgumentException("Invalid first name format");
+        }
+
+        // Validate format for last name (allow Vietnamese)
+        if (!ValidationUtils.IsValidName(request.LastName))
+        {
+            throw new ArgumentException("Invalid last name format");
+        }
+
+        // Check if the email already exists in the database
+        var existingEmail = await context.AppUsers.AsNoTracking().FirstOrDefaultAsync(u => u.Email == request.Email, cancellationToken);
+
+        if (existingEmail is not null)
+        {
+            throw new InvalidOperationException("Email already exists");
+        }
+
+        // Validate password and confirm password
+        if (request.Password != request.ConfirmPassword)
+        {
+            throw new ArgumentException("Passwords do not match");
+        }
+
+        // Validate password length
+        if (request.Password.Length < 6)
+        {
+            throw new ArgumentException("Password must be at least 6 characters long");
+        }
+
+        // Create a new AppUser entity and set its properties
+        var newUser = new AppUser
+        {
+            Email = request.Email,
+            PasswordHash = passwordHasher.HashPassword(request.Password),
+            FirstName = request.FirstName,
+            LastName = request.LastName,
+            Role = request.Role ?? "Student",
+            IsActive = true,
+        };
+
+        // Add the new user to the database and save changes
+        context.AppUsers.Add(newUser);
+        await context.SaveChangesAsync(cancellationToken);
+
+        return await GenerateAuthResponseAsync(newUser, cancellationToken);
     }
 
-    // Check if the user account is active
-    if (!user.IsActive)
+    public async Task<UserDto> GetCurrentUserAsync(Guid userId, CancellationToken cancellationToken = default)
     {
-      throw new InvalidOperationException("User account is inactive");
+        // Query the user from the database based on the provided Id
+        var user = await context.AppUsers.AsNoTracking().FirstOrDefaultAsync(u => u.Id == userId, cancellationToken);
+
+        // Check if user found
+        if (user is null)
+            throw new KeyNotFoundException("User not found");
+
+        // Return the user profile info
+        return new UserDto(user.Id, user.Email, user.FirstName, user.LastName, user.Role, user.IsActive, user.CreatedAt, user.UpdatedAt);
     }
 
-    return await GenerateAuthResponseAsync(user, cancellationToken);
-  }
-
-  public async Task<AuthResponse> RegisterAsync(RegisterRequest request, CancellationToken cancellationToken = default)
-  {
-    // Validate the input parameters
-    if (string.IsNullOrWhiteSpace(request.Email) || string.IsNullOrWhiteSpace(request.Password) || string.IsNullOrWhiteSpace(request.ConfirmPassword) || string.IsNullOrWhiteSpace(request.FirstName) || string.IsNullOrWhiteSpace(request.LastName))
+    private async Task<AuthResponse> GenerateAuthResponseAsync(AppUser user, CancellationToken cancellationToken)
     {
-      throw new ArgumentException("Email, password, and confirm password are required");
+        // Generate access token and refresh token
+        string accessToken = jwtTokenGenerator.GenerateToken(user);
+        string refreshToken = Convert.ToBase64String(RandomNumberGenerator.GetBytes(64));
+
+        // Create a new RefreshToken entity and set its properties
+        var refreshTokenEntity = new RefreshToken
+        {
+            UserId = user.Id,
+            Token = refreshToken,
+            ExpiresAt = DateTime.UtcNow.AddDays(7),
+            IsRevoked = false
+        };
+
+        // Add the refresh token entity to the database context and save changes
+        context.RefreshTokens.Add(refreshTokenEntity);
+        await context.SaveChangesAsync(cancellationToken);
+
+        // Create a UserDto object to include user information in the response
+        var userDto = new UserDto(user.Id, user.Email, user.FirstName, user.LastName, user.Role, user.IsActive, user.CreatedAt, user.UpdatedAt);
+
+        // Return the authentication response with the generated tokens and user information
+        return new AuthResponse(accessToken, refreshToken, "Bearer", 3600, userDto);
     }
-
-    // Check if the email already exists in the database
-    var existingEmail = await context.AppUsers.AsNoTracking().FirstOrDefaultAsync(u => u.Email == request.Email, cancellationToken);
-
-    if (existingEmail is not null)
-    {
-      throw new InvalidOperationException("Email already exists");
-    }
-
-    // Validate password and confirm password
-    if (request.Password != request.ConfirmPassword)
-    {
-      throw new ArgumentException("Passwords do not match");
-    }
-
-    // Validate password length
-    if (request.Password.Length < 6)
-    {
-      throw new ArgumentException("Password must be at least 6 characters long");
-    }
-
-    // Create a new AppUser entity and set its properties
-    var newUser = new AppUser
-    {
-      Email = request.Email,
-      PasswordHash = passwordHasher.HashPassword(request.Password),
-      FirstName = request.FirstName,
-      LastName = request.LastName,
-      Role = request.Role ?? "Student",
-      IsActive = true,
-    };
-
-    // Add the new user to the database and save changes
-    context.AppUsers.Add(newUser);
-    await context.SaveChangesAsync(cancellationToken);
-
-    return await GenerateAuthResponseAsync(newUser, cancellationToken);
-  }
-
-  public async Task<UserDto> GetCurrentUserAsync(Guid userId, CancellationToken cancellationToken = default)
-  {
-    // Query the user from the database based on the provided Id
-    var user = await context.AppUsers.AsNoTracking().FirstOrDefaultAsync(u => u.Id == userId, cancellationToken);
-
-    // Check if user found
-    if (user is null)
-      throw new KeyNotFoundException("User not found");
-
-    // Return the user profile info
-    return new UserDto(user.Id, user.Email, user.FirstName, user.LastName, user.Role, user.IsActive, user.CreatedAt, user.UpdatedAt);
-  }
-
-  private async Task<AuthResponse> GenerateAuthResponseAsync(AppUser user, CancellationToken cancellationToken)
-  {
-    // Generate access token and refresh token
-    string accessToken = jwtTokenGenerator.GenerateToken(user);
-    string refreshToken = Convert.ToBase64String(RandomNumberGenerator.GetBytes(64));
-
-    // Create a new RefreshToken entity and set its properties
-    var refreshTokenEntity = new RefreshToken
-    {
-      UserId = user.Id,
-      Token = refreshToken,
-      ExpiresAt = DateTime.UtcNow.AddDays(7),
-      IsRevoked = false
-    };
-
-    // Add the refresh token entity to the database context and save changes
-    context.RefreshTokens.Add(refreshTokenEntity);
-    await context.SaveChangesAsync(cancellationToken);
-
-    // Create a UserDto object to include user information in the response
-    var userDto = new UserDto(user.Id, user.Email, user.FirstName, user.LastName, user.Role, user.IsActive, user.CreatedAt, user.UpdatedAt);
-
-    // Return the authentication response with the generated tokens and user information
-    return new AuthResponse(accessToken, refreshToken, "Bearer", 3600, userDto);
-  }
 }

--- a/src/PRN212.AIStudyHub.Application/Utils/ValidationUtils.cs
+++ b/src/PRN212.AIStudyHub.Application/Utils/ValidationUtils.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace PRN212.AIStudyHub.Application.Utils
+{
+    public static class ValidationUtils
+    {
+        public static bool IsValidEmail(string email)
+        {
+            if (string.IsNullOrEmpty(email)) return false;
+            string emailPattern = @"^[a-zA-Z0-9._%+-]+@(gmail\.com|hotmail\.com|outlook\.com|yahoo\.com)$";
+            return Regex.IsMatch(email, emailPattern, RegexOptions.IgnoreCase); // Cho phép 4 loại mai : Gmail, Outlook, Hotmail, yahoo
+        }
+        public static bool IsValidName(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name)) return false;
+            string namePattern = @"^[\p{L}\s]+$";                           // Hỗ trợ tiếng Việt và khoảng trắng
+            return Regex.IsMatch(name, namePattern);
+        }
+    }
+}

--- a/src/PRN212.AIStudyHub.Domain/Entities/RefreshToken.cs
+++ b/src/PRN212.AIStudyHub.Domain/Entities/RefreshToken.cs
@@ -1,5 +1,5 @@
 namespace PRN212.AIStudyHub.Domain.Entities;
-
+using System.ComponentModel.DataAnnotations.Schema;
 public class RefreshToken
 {
   public Guid Id { get; private set; }
@@ -9,7 +9,8 @@ public class RefreshToken
   public bool IsRevoked { get; set; } = false;
   public DateTime CreatedAt { get; private set; }
 
-  public virtual AppUser User { get; set; } = null!;
+    [ForeignKey("UserId")]
+    public virtual AppUser User { get; set; } = null!;
 
   public RefreshToken()
   {

--- a/src/PRN212.AIStudyHub.Infrastructure/Data/AistudyHubDbContext.cs
+++ b/src/PRN212.AIStudyHub.Infrastructure/Data/AistudyHubDbContext.cs
@@ -23,6 +23,12 @@ public class AistudyHubDbContext : DbContext, IAppDbContext
   {
     base.OnModelCreating(modelBuilder);
 
+    // Map all DbSets to singular table names (matching Entity names)
+    foreach (var entity in modelBuilder.Model.GetEntityTypes())
+    {
+      entity.SetTableName(entity.ClrType.Name);
+    }
+
     modelBuilder.ApplyConfigurationsFromAssembly(typeof(AistudyHubDbContext).Assembly);
   }
 }

--- a/src/PRN212.AIStudyHub.Infrastructure/Data/Configurations/RefreshTokenConfiguration.cs
+++ b/src/PRN212.AIStudyHub.Infrastructure/Data/Configurations/RefreshTokenConfiguration.cs
@@ -13,7 +13,7 @@ public class RefreshTokenConfiguration : IEntityTypeConfiguration<RefreshToken>
     builder.Property(r => r.Token).IsRequired().HasMaxLength(256);
 
     builder.HasOne(r => r.User)
-           .WithMany()
+           .WithMany(u => u.RefreshTokens)
            .HasForeignKey(r => r.UserId)
            .OnDelete(DeleteBehavior.Cascade);
   }

--- a/src/PRN212.AIStudyHub.WebAPI/Properties/launchSettings.json
+++ b/src/PRN212.AIStudyHub.WebAPI/Properties/launchSettings.json
@@ -1,11 +1,12 @@
-﻿{
+{
   "$schema": "https://json.schemastore.org/launchsettings.json",
   "profiles": {
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": false,
+      "launchBrowser": true,
       "applicationUrl": "http://localhost:5032",
+      "launchUrl": "swagger",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -13,8 +14,9 @@
     "https": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": false,
+      "launchBrowser": true,
       "applicationUrl": "https://localhost:7165;http://localhost:5032",
+      "launchUrl": "swagger",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
- Thêm validation cho email và name trong phần đăng kí và đăng nhập.
- Sửa lại RefreshToken (cho nó ánh xạ đúng với cột UserId trong AppUser vì ban đầu EFCore đang tự ánh xạ với AppUserId chứ không phải UserId).
- Sửa DbContext (ghi đè lại cấu hình OnModelCreating để ép EF Core tự động bỏ "s" để truy vấn đúng tên bảng trong database).
- Sửa launchSettings.json (cho phép mở trình duyệt lên bằng trang swagger để test các API) //alow Https,Http.
* Bỏ qua các commit của WPF 